### PR TITLE
Keep .v file around

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,6 +34,6 @@ clean:
 	rm -f *.bin *.txt *.blif *.rpt *.v *.pcf
 
 
-.PRECIOUS: %.bin %.txt %.blif 
+.PRECIOUS: %.bin %.txt %.blif %.v
 
 .PHONY: all explain install clean


### PR DESCRIPTION
Since we keep the other intermediate files around, we may as well keep the .v file around for debugging.